### PR TITLE
[수인] : metadat 이미지 Listup 저장 안되는 에러 해결

### DIFF
--- a/fromis_7_be/src/main/java/com/example/fromis_7_be/listup/service/ListupService.java
+++ b/fromis_7_be/src/main/java/com/example/fromis_7_be/listup/service/ListupService.java
@@ -39,14 +39,14 @@ public class ListupService {
                     } catch (IOException e) {
                         metadata = new HashMap<>();
                         metadata.put("title", null);
-                        metadata.put("image", null);
+                        metadata.put("thumbnailUrl", null);
                         metadata.put("description", null);
                     }
 
                     return Listup.from(
                             (String) metadata.get("title"),
                             url,
-                            (String) metadata.get("image"),
+                            (String) metadata.get("thumbnailUrl"),
                             description,
                             category
                     );


### PR DESCRIPTION
Matadata thumbnailUrl 설정 이슈로 인한 Listup 이미지 업데이트 안되었는데 수정해서 해결했습니다. 